### PR TITLE
On Julia 1.8+, don't call `Pkg.PlatformEngines.probe_platform_engines!()`

### DIFF
--- a/src/DebugArtifacts.jl
+++ b/src/DebugArtifacts.jl
@@ -45,7 +45,9 @@ function debug_artifact(artifact_name::String, platform = platform_key_abi())
     println()
 
     # Initialize Pkg code
-    probe_platform_engines!(; verbose=true)
+    @static if Base.VERSION < v"1.8-"
+        probe_platform_engines!(; verbose=true)
+    end
 
     # Change these to whatever you need them to be, to debug your artifacts code
     artifacts_toml_url = "https://raw.githubusercontent.com/JuliaBinaryWrappers/$(artifact_name)_jll.jl/master/Artifacts.toml"


### PR DESCRIPTION
Fixes #1

In https://github.com/JuliaLang/Pkg.jl/commit/827a740800d047074046f89835e903cc49ba31e2, `probe_platform_engines!()` was turned into an empty function that does nothing.

In https://github.com/JuliaLang/Pkg.jl/commit/67ed9cb3541368e3f98867ed809de7c6db32f4cc, it was removed completely.